### PR TITLE
misc: Fix LLVM team dropping libclang-rt-dev dependency

### DIFF
--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -144,6 +144,14 @@ jobs:
         env:
           CC: ${{ matrix.compiler }}
         working-directory: ${{ runner.temp }}
+      - name: Add coverage dependency
+        if: matrix.compiler == 'clang-14'
+        shell: bash
+        run: |
+          apt download libclang-rt-14-dev
+          PACKAGE=$(find . -name 'libclang-rt-14*.deb')
+          sudo dpkg --install --force-breaks $PACKAGE
+        working-directory: ${{ runner.temp }}
       - name: Checkout
         uses: actions/checkout@v3
       - name: Setup Meson + Ninja


### PR DESCRIPTION
See https://groups.google.com/g/linux.debian.bugs.dist/c/jFEvS84SakQ