### PR TITLE
misc: Added a note of commit signatures

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -18,6 +18,7 @@ Information embedded in the description part of the commits doesn't count.
 * [ ] It builds and lints cleanly (`ninja` in the bootstrap build directory is cleanly successful, clang-tidy does not warn about new issues)
 * [ ] I've tested it to the best of my ability
 * [ ] My commit messages provide a useful short description of what the commits do
+* [ ] I've made sure that my commits are [signed/verified](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification)
 
 ## Closing issues
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,6 +35,11 @@ Except for creating the build environment, the rest of these steps expect to be 
 
 ## Submitting a pull request
 
+**Note**: All commits must be signed/verified. This is an additional security measure to verify
+the source of every commit.
+
+You can read more about commit signature verification from [Github Docs](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification).
+
 ### If contributing for the first time
 
 1. [Fork](https://github.com/mangrove-lang/mangrove) and clone the repository


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

## Detailed description
Signing/verifying commits on Github is not a standard practice for every project so we should explicitly tell contributors that we do require it. And remind them about it every time a PR is created, just in case.
Note that I've manually added the new item to this PR's checklist.
<!--
Explain the **details** for making this change.
* Is a new feature implemented?
* What existing problem(s) does the pull request solve?
* How does the pull request solve these problems?
Please provide enough information so that others can review your pull request.
Information embedded in the description part of the commits doesn't count.
-->

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/mangrove-lang/mangrove/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/mangrove-lang/mangrove/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds and lints cleanly (`ninja` in the bootstrap build directory is cleanly successful, clang-tidy does not warn about new issues)
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do
* [x] I've made sure that my commits are [signed/verified](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification)

## Closing issues

<!-- put "fixes #XXXX" here to auto-close the issue(s) that your PR fixes (if any). -->
