### PR TITLE
bootstrap/parser: Fixed not-keyword to be a TokenType::invert

### DIFF
--- a/src/bootstrap/parser/tokeniser.cxx
+++ b/src/bootstrap/parser/tokeniser.cxx
@@ -171,7 +171,7 @@ void Tokeniser::readExtendedToken() noexcept
 		else if (token == u8"or"_sv)
 			_token.set(TokenType::logicOp, '|'_u8c);
 		else if (token == u8"not"_sv)
-			_token.set(TokenType::logicOp, '!'_u8c);
+			_token.set(TokenType::invert, '!'_u8c);
 		else if (isLocationSpec(token))
 			_token.set(TokenType::locationSpec);
 		else if (isStorageSpec(token))

--- a/test/bootstrap/parser/testTokeniser.cxx
+++ b/test/bootstrap/parser/testTokeniser.cxx
@@ -291,7 +291,7 @@ private:
 		readValue(tokeniser, TokenType::logicOp, u8"|"_sv);
 		readNewline(tokeniser);
 		console.info("Checking tokenisation of 'not'"sv);
-		readValue(tokeniser, TokenType::logicOp, u8"!"_sv);
+		readValue(tokeniser, TokenType::invert, u8"!"_sv);
 		readNewline(tokeniser);
 		console.info("Checking tokenisation of 'eeprom'"sv);
 		readValue(tokeniser, TokenType::locationSpec, u8"eeprom"_sv);


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

## Detailed description
According to [BNF](https://github.com/mangrove-lang/mangrove-doc/blob/main/mangrove.bnf#L50-L51) the `not` keyword should be `TokenType::invert`, not a `TokenType::logicOp`. This commit fixes that issue.

<!--
Explain the **details** for making this change.
* Is a new feature implemented?
* What existing problem(s) does the pull request solve?
* How does the pull request solve these problems?
Please provide enough information so that others can review your pull request.
Information embedded in the description part of the commits doesn't count.
-->

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/mangrove-lang/mangrove/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/mangrove-lang/mangrove/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds and lints cleanly (`ninja` in the bootstrap build directory is cleanly successful, clang-tidy does not warn about new issues)
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do
* [x] I've made sure that my commits are [signed/verified](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification)

## Closing issues

<!-- put "fixes #XXXX" here to auto-close the issue(s) that your PR fixes (if any). -->
